### PR TITLE
Fix missing process variable 

### DIFF
--- a/lib/WAAClock.js
+++ b/lib/WAAClock.js
@@ -155,7 +155,7 @@ WAAClock.prototype.start = function() {
       this._clockNode = this.context.createScriptProcessor(bufferSize, 1, 1)
       this._clockNode.connect(this.context.destination)
       this._clockNode.onaudioprocess = function () {
-        process.nextTick(function() { self._tick() })
+        setTimeout(function() { self._tick() }, 0)
       }
     } else if (this.tickMethod === 'manual') null // _tick is called manually
 


### PR DESCRIPTION
I'm currently using WAAClock on a Svelte project using Vite. Vite performs some clever CommonJS resolution, but throws when trying to access `process.nextTick`. After a bit of [research](https://github.com/browserify/browserify/issues/237), it appears that `process` can be required~, which is what this PR does!

(I think this is what browserify adds to the built file, but given that Vite appears to be using the source files, this needs to be manually included.)~

Edit: this PR replaces `process.nextTick` with `setTimeout` as discussed below.